### PR TITLE
Feature: export-updates

### DIFF
--- a/orko/_01-foot.mustache
+++ b/orko/_01-foot.mustache
@@ -1,10 +1,10 @@
         <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
         <script type="module" src="../../js/main.js"></script>
-	    <script nomodule src="../../js/nomodule/main.js"></script>
+	    <script nomodule src="../../js/main-nomodule.js"></script>
 
         <!-- Begin Pattern Lab JS -->
         {{{ patternLabFoot }}}
         <!-- End Pattern Lab JS -->
-        
+
     </body>
 </html>

--- a/orko/package.json
+++ b/orko/package.json
@@ -12,7 +12,7 @@
         "@deg-skeletor/core": "^1.0.0",
         "@deg-skeletor/plugin-copy": "^1.0.2",
         "@deg-skeletor/plugin-express": "^1.0.0",
-        "@deg-skeletor/plugin-patternlab": "^3.1.0",
+        "@deg-skeletor/plugin-patternlab": "^3.2.0",
         "@deg-skeletor/plugin-postcss": "^1.0.0",
         "@deg-skeletor/plugin-rollup": "^2.0.2",
         "@deg-skeletor/plugin-watch": "^1.0.0",

--- a/skeletor/common/css.config.js
+++ b/skeletor/common/css.config.js
@@ -14,7 +14,6 @@ module.exports = {
     	require('postcss-custom-media'),
    		require('postcss-color-mod-function'),
     	require('postcss-nested'),
-    	require('autoprefixer'),
-		require('cssnano')
+    	require('autoprefixer')
 	]
 };

--- a/skeletor/common/js.config.js
+++ b/skeletor/common/js.config.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 const legacyBabelPresets = [
     [
         '@babel/preset-env',

--- a/skeletor/common/js.config.js
+++ b/skeletor/common/js.config.js
@@ -27,10 +27,11 @@ module.exports = {
     output: function(destPath, isModern = true) {
         return [
             {
-                dir: isModern ? destPath : path.join(destPath, 'nomodule'),
-                format: isModern ? "es" : "iife"
+                dir: destPath,
+                format: isModern ? 'es' : 'iife',
+                entryFileNames: isModern ? '[name].js' : '[name]-nomodule.js'
             }
-        ]
+        ];
     },
     plugins: (isModern = true) => [
         require('rollup-plugin-replace')({

--- a/skeletor/common/patterns.config.js
+++ b/skeletor/common/patterns.config.js
@@ -65,16 +65,27 @@ module.exports = {
             layout: 'horizontal'
         }
     },
-    patternExport: [
-        {
-            patterns: 'components/*',
-            dest: './export/patterns/',
-            includeHeadFoot: false
-        },
-        {
-            patterns: 'pages/*',
-            dest: './export/patterns/',
-            includeHeadFoot: true
-        }
-    ]
+    patternExport: {
+        patternGroups: [
+            {
+                patterns: 'pages/*',
+                dest: './export',
+                includeHeadFoot: true
+            }
+        ],
+        assetPathReplacements: [
+            {
+                path: '../../images/',
+                replacementPath: ''
+            },
+            {
+                path: '../../css/',
+                replacementPath: ''
+            },
+            {
+                path: '../../js/',
+                replacementPath: ''
+            }
+        ]
+    }
 };

--- a/skeletor/common/patterns.config.js
+++ b/skeletor/common/patterns.config.js
@@ -70,7 +70,8 @@ module.exports = {
             {
                 patterns: 'pages/*',
                 dest: './export',
-                includeHeadFoot: true
+                includeHeadFoot: true,
+                flatten: false
             }
         ],
         assetPathReplacements: [

--- a/skeletor/export/css.config.js
+++ b/skeletor/export/css.config.js
@@ -8,7 +8,7 @@ module.exports = {
             name: '@deg-skeletor/plugin-postcss',
             config: {
                 files: [
-                    ...files(`${outputDir}/css/`)
+                    ...files(`${outputDir}`)
                 ],
                 plugins
             }

--- a/skeletor/export/js.config.js
+++ b/skeletor/export/js.config.js
@@ -1,6 +1,6 @@
 const {input, output, plugins} = require('../common/js.config.js');
 const terser = require('rollup-plugin-terser').terser();
-const outputDir = 'export/js';
+const outputDir = 'export';
 
 module.exports = {
 	name: 'js',

--- a/skeletor/export/static.config.js
+++ b/skeletor/export/static.config.js
@@ -8,8 +8,8 @@ module.exports = {
             name: '@deg-skeletor/plugin-copy',
             config: {
                 directories: directories({
-					imagesDestPath: `${outputDir}/images/`,
-					fontsDestPath: `${outputDir}/fonts/`
+					imagesDestPath: `${outputDir}`,
+					fontsDestPath: `${outputDir}`
 				})
             }
         }


### PR DESCRIPTION
This update eases the export process in the following ways:

1. Only exports pages rather than components & pages
2. Exports all files into a flat directory (requested by SFMC engineers)*
3. Exports unminified CSS (requested by SFMC engineers)
4. Updates all asset references to current directory during export

*Pages are the only items still exported into a folder within the export directory. They will need to be moved one level up into the main export folder. This is an item I will be working to resolve in the future.