### PR TITLE
fixed JS skeletor config to not use code splitting

### DIFF
--- a/skeletor/build/js.config.js
+++ b/skeletor/build/js.config.js
@@ -1,4 +1,4 @@
-const {input, output, plugins} = require('../common/js.config.js');
+const {rollupConfig} = require('../common/js.config.js');
 const outputDir = 'patternlab/js';
 
 module.exports = {
@@ -6,20 +6,7 @@ module.exports = {
 	plugins: [
 		{
 			name: '@deg-skeletor/plugin-rollup',
-			config: [
-                {
-                    input,
-                    output: output(outputDir),
-                    plugins: plugins(),
-                    experimentalCodeSplitting: true
-                },
-                {
-                    input,
-                    output: output(outputDir, false),
-                    plugins: plugins(false),
-                    experimentalCodeSplitting: true
-                }
-            ]
+			config: rollupConfig(outputDir)
         }
 	]
 };

--- a/skeletor/common/js.config.js
+++ b/skeletor/common/js.config.js
@@ -1,5 +1,9 @@
 const path = require('path');
 
+const rollupFiles = {
+    'source/js/main.js': 'main.js'
+};
+
 const legacyBabelPresets = [
     [
         '@babel/preset-env',
@@ -20,19 +24,17 @@ const modernBabelPresets = [
     ]
 ];
 
-module.exports = {
-    input: [
-        'source/js/main.js'
-    ],
-    output: function(destPath, isModern = true) {
-        return [
-            {
-                dir: isModern ? destPath : path.join(destPath, 'nomodule'),
-                format: isModern ? "es" : "iife"
-            }
-        ]
-    },
-    plugins: (isModern = true) => [
+function createRollupOutput(outputFile, isModern = true) {
+    return [
+        {
+            file: outputFile,
+            format: isModern ? "es" : "iife"
+        }
+    ]
+}
+
+function createRollupPlugins(isModern, minify){
+    const plugins = [
         require('rollup-plugin-replace')({
             ENVIRONMENT: () => JSON.stringify(process.env.NODE_ENV || 'development'),
             'process.env.NODE_ENV': () => JSON.stringify(process.env.NODE_ENV || 'development')
@@ -51,5 +53,42 @@ module.exports = {
         require('rollup-plugin-commonjs')({
             include: 'node_modules/**'
         })
-    ]
+    ];
+
+    if(minify) {
+        plugins.push(require('rollup-plugin-terser').terser());
+    }
+
+    return plugins;
+}
+
+function getOutputFilepath(outputFilename, destPath, isModern) {
+    const filename = isModern ? 
+        outputFilename : 
+        `${path.basename(outputFilename, '.js')}-nomodule.js`;
+
+    return path.join(destPath, filename);
+}
+
+function createRollupConfigForFile(inputFile, outputFile, isModern, minify) {
+    return {
+        input: inputFile,
+        output: createRollupOutput(outputFile, isModern),
+        plugins: createRollupPlugins(isModern, minify)
+    }
+}
+
+module.exports = {
+    rollupConfig: function(destPath, minify = false) {
+        return Object.keys(rollupFiles).reduce((accum, inputFile) => {
+
+            const outputFile = getOutputFilepath(rollupFiles[inputFile], destPath, true);
+            accum.push(createRollupConfigForFile(inputFile, outputFile, true, minify));
+
+            const legacyOutputFile = getOutputFilepath(rollupFiles[inputFile], destPath, false);
+            accum.push(createRollupConfigForFile(inputFile, legacyOutputFile, false, minify));
+            
+            return accum;
+        }, []);
+    }
 };

--- a/skeletor/export/js.config.js
+++ b/skeletor/export/js.config.js
@@ -1,5 +1,4 @@
-const {input, output, plugins} = require('../common/js.config.js');
-const terser = require('rollup-plugin-terser').terser();
+const {rollupConfig} = require('../common/js.config.js');
 const outputDir = 'export/js';
 
 module.exports = {
@@ -7,26 +6,7 @@ module.exports = {
 	plugins: [
 		{
 			name: '@deg-skeletor/plugin-rollup',
-			config: [
-                {
-                    input,
-                    output: output(outputDir),
-                    plugins: [
-                        ...plugins(),
-                        terser
-                    ],
-                    experimentalCodeSplitting: true
-                },
-                {
-                    input,
-                    output: output(outputDir, false),
-                    plugins: [
-                        ...plugins(false),
-                        terser
-                    ],
-                    experimentalCodeSplitting: true
-                }
-            ]
+			config: rollupConfig(outputDir, true)
 		}
 	]
 };


### PR DESCRIPTION
SFMC templates were set up to use Rollup's code splitting, which it doesn't need. I updated the JS skeletor configuration to just use normal old Rollup bundles.